### PR TITLE
Update README and add cheatsheets for acme.sh and certbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,27 +69,28 @@ cs -l
 cs -h
 ```
 
+
 <details>
 <summary>让别名支持交互式菜单</summary>
-如果你希望别名支持交互式菜单，可以使用以下命令：
+  如果你希望别名支持交互式菜单，可以使用以下命令：
 
-```bash
-alias cs='() {
-  local tmpfile=$(mktemp)
-  curl -sSL "https://raw.githubusercontent.com/funnyzak/cli-cheatsheets/refs/heads/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && "$tmpfile" "$@" && rm -f "$tmpfile"
-}'
-```
-配置完成后，然后执行 `source ~/.bashrc` 或 `source ~/.zshrc` 使配置生效。
+  ```bash
+  alias cs='() {
+    local tmpfile=$(mktemp)
+    curl -sSL "https://raw.githubusercontent.com/funnyzak/cli-cheatsheets/refs/heads/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && "$tmpfile" "$@" && rm -f "$tmpfile"
+  }'
+  ```
+  配置完成后，然后执行 `source ~/.bashrc` 或 `source ~/.zshrc` 使配置生效。
 
 
-如果不方便访问 `raw.githubusercontent.com`，可以使用以下命令，使用 `Gitee` 的镜像地址：
+  如果不方便访问 `raw.githubusercontent.com`，可以使用以下命令，使用 `Gitee` 的镜像地址：
 
-```bash
-alias cs='() {
-  local tmpfile=$(mktemp)
-  curl -sSL "https://gitee.com/funnyzak/cli-cheatsheets/raw/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && CLI_CHEATSHEET_REGION=cn "$tmpfile" "$@" && rm -f "$tmpfile"
-}'
-```
+  ```bash
+  alias cs='() {
+    local tmpfile=$(mktemp)
+    curl -sSL "https://gitee.com/funnyzak/cli-cheatsheets/raw/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && CLI_CHEATSHEET_REGION=cn "$tmpfile" "$@" && rm -f "$tmpfile"
+  }'
+  ```
 </details>
 
 #### Fish

--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ wget -qO- https://cs.yycc.dev | bash -s -- git
 
 将以下代码添加到你的 `~/.bashrc` 或 `~/.zshrc` 文件中：
 
-**简化版本：**
-
 ```bash
 alias cs='() { curl -s https://raw.githubusercontent.com/funnyzak/cli-cheatsheets/refs/heads/main/cheatsheet.sh | bash -s -- "$@" }'
+```
+
+`Gitee` 镜像地址：
+```bash
+alias cs='() { curl -s https://gitee.com/funnyzak/cli-cheatsheets/raw/main/cheatsheet.sh | CLI_CHEATSHEET_REGION=cn bash -s -- "$@" }'
 ```
 
 使用如下命令查看速查表：
@@ -61,12 +64,15 @@ alias cs='() { curl -s https://raw.githubusercontent.com/funnyzak/cli-cheatsheet
 # 显示GIT速查表
 cs git
 # 显示所有支持的命令速查表
-cs
+cs -l
+# 帮助
+cs -h
 ```
 
-**完整版本：** 此方式包含交互式菜单。
+<details>
+<summary>让别名支持交互式菜单</summary>
+如果你希望别名支持交互式菜单，可以使用以下命令：
 
-在 `~/.zshrc` 中添加以下代码：
 ```bash
 alias cs='() {
   local tmpfile=$(mktemp)
@@ -84,6 +90,7 @@ alias cs='() {
   curl -sSL "https://gitee.com/funnyzak/cli-cheatsheets/raw/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && CLI_CHEATSHEET_REGION=cn "$tmpfile" "$@" && rm -f "$tmpfile"
 }'
 ```
+</details>
 
 #### Fish
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,20 @@ cs
 ```bash
 alias cs='() {
   local tmpfile=$(mktemp)
-  curl -sSL "https://raw.githubusercontent.com/funnyzak/cli-cheatsheets/refs/heads/${REPO_BRANCH:-main}/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && "$tmpfile" "$@" && rm -f "$tmpfile"
+  curl -sSL "https://raw.githubusercontent.com/funnyzak/cli-cheatsheets/refs/heads/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && "$tmpfile" "$@" && rm -f "$tmpfile"
 }'
 ```
 配置完成后，然后执行 `source ~/.bashrc` 或 `source ~/.zshrc` 使配置生效。
+
+
+如果不方便访问 `raw.githubusercontent.com`，可以使用以下命令，使用 `Gitee` 的镜像地址：
+
+```bash
+alias cs='() {
+  local tmpfile=$(mktemp)
+  curl -sSL "https://gitee.com/funnyzak/cli-cheatsheets/raw/main/cheatsheet.sh" -o "$tmpfile" && chmod +x "$tmpfile" && CLI_CHEATSHEET_REGION=cn "$tmpfile" "$@" && rm -f "$tmpfile"
+}'
+```
 
 #### Fish
 
@@ -390,6 +400,8 @@ CLI 速查表按类别组织在以下目录中：
 (`cheatsheets/security/`) 安全工具
 
 * `nmap-cheatsheet.txt`: nmap 网络扫描工具命令
+* `certbot-cheatsheet.txt`: certbot Let's Encrypt 证书管理工具命令
+* `acme.sh-cheatsheet.txt`: acme.sh Let's Encrypt 证书管理工具命令
 
 ### Version Control
 

--- a/cheatsheet.sh
+++ b/cheatsheet.sh
@@ -17,6 +17,8 @@
 #
 # 环境变量:
 #   CLI_CHEATSHEET_PATH: 自定义速查表存放路径
+#   CLI_CHEATSHEET_CACHE_DIR: 临时目录，用于缓存命令速查表(默认: /tmp/cheatsheet_cache)
+#   CLI_CHEATSHEET_REGION: 设置为 "cn" 使用中国区URL(默认：自动检测)
 
 # 脚本错误处理
 set -euo pipefail
@@ -202,6 +204,12 @@ COMMAND_DESCRIPTIONS["python"]="Python 运行时"
 # 安全工具类命令
 COMMAND_CATEGORIES["nmap"]="security"
 COMMAND_DESCRIPTIONS["nmap"]="网络扫描工具"
+
+COMMAND_CATEGORIES["acme.sh"]="security"
+COMMAND_DESCRIPTIONS["acme.sh"]="获取和续订 Let's Encrypt 证书"
+
+COMMAND_CATEGORIES["certbot"]="security"
+COMMAND_DESCRIPTIONS["certbot"]="Let's Encrypt 证书管理工具"
 
 
 # 操作系统命令 (OS Commands)
@@ -446,6 +454,7 @@ show_help() {
   echo "环境变量:"
   echo "  CLI_CHEATSHEET_PATH: 自定义速查表存放路径"
   echo "  CLI_CHEATSHEET_CACHE_DIR: 临时目录，用于缓存命令速查表(默认: /tmp/cheatsheet_cache)"
+  echo "  CLI_CHEATSHEET_REGION: 设置为 'cn' 使用中国区URL(默认：自动检测)"
   echo ""
 }
 
@@ -673,6 +682,8 @@ main() {
   # 确定使用哪个URL前缀
   if [[ -n "$custom_url" ]]; then
     base_url="$custom_url"
+  elif [[ "${CLI_CHEATSHEET_REGION:-}" =~ ^[cC][nN]$ ]]; then
+    base_url="$CN_URL"
   else
     base_url=$(detect_best_url)
   fi

--- a/cheatsheets/security/acme.sh-cheatsheet.txt
+++ b/cheatsheets/security/acme.sh-cheatsheet.txt
@@ -1,0 +1,164 @@
+##############################################################################
+# acme.sh 速查表 (acme.sh Cheatsheet)
+# 用于获取和续订 Let's Encrypt (及其他 ACME CA) 证书的 Shell 脚本
+# https://github.com/funnyzak/cli-cheatsheets
+# https://github.com/acmesh-official/acme.sh
+##############################################################################
+
+# 图例 (Legend):
+#   - DOMAIN:      你的域名 (Your domain name, e.g., example.com, www.example.com)
+#   - WEBROOT:     网站的根目录路径 (Web root path, e.g., /var/www/html)
+#   - DNS_API_HOOK: DNS 提供商的 API 钩子名称 (e.g., dns_cf, dns_ali, dns_dp)
+#   - CERT_PATH:   证书文件路径 (Certificate file path)
+#   - KEY_PATH:    私钥文件路径 (Private key file path)
+#   - CA_PATH:     中间证书文件路径 (Intermediate CA certificate file path)
+#   - FULLCHAIN_PATH: 包含证书和中间证书的文件路径 (Full chain certificate path)
+#   - RELOAD_CMD:  重载 Web 服务器配置的命令 (Command to reload web server)
+#   - EMAIL:       你的邮箱地址 (Your email address for registration/notifications)
+
+##############################################################################
+# 安装与设置 (Installation & Setup)
+##############################################################################
+
+# 从 GitHub 安装 (推荐)
+# curl https://get.acme.sh | sh -s email=EMAIL
+# wget -O - https://get.acme.sh | sh -s email=EMAIL
+
+acme.sh --upgrade                             # 升级 acme.sh 到最新版本
+acme.sh --uninstall                           # 卸载 acme.sh
+acme.sh --register-account -m EMAIL           # 注册 ACME 账户 (通常安装时自动完成)
+acme.sh --update-account -m NEW_EMAIL         # 更新账户邮箱
+acme.sh --set-default-ca --server letsencrypt # 设置默认 CA 为 Let's Encrypt
+acme.sh --set-default-ca --server zerossl     # 设置默认 CA 为 ZeroSSL (可能需要 EAB 凭证)
+
+# 提示:
+#   - 安装后会自动添加一个 cron 任务用于自动续订证书。使用 `crontab -l` 查看。
+#   - 配置文件位于 ~/.acme.sh/account.conf
+
+##############################################################################
+# 证书颁发 (Issuing Certificates)
+##############################################################################
+
+# --- 通用选项 ---
+acme.sh --issue -d DOMAIN ...                 # 颁发证书的基本命令
+acme.sh --issue -d d1.com -d d2.com ...       # 颁发 SAN (多域名) 证书
+acme.sh --issue ... --test                    # 使用 Let's Encrypt Staging 环境测试 (强烈推荐首次使用)
+acme.sh --issue ... --keylength 4096          # 指定密钥长度 (默认 2048)
+acme.sh --issue ... --keylength ec-256        # 使用 ECDSA 证书 (可选 ec-384)
+
+# --- HTTP-01 验证 (需要 80 端口) ---
+acme.sh --issue -d DOMAIN -w WEBROOT          # 使用 Webroot 模式 (推荐用于运行中的 Web 服务器)
+acme.sh --issue -d DOMAIN --standalone        # 使用 Standalone 模式 (acme.sh 会临时监听 80 端口)
+acme.sh --issue -d DOMAIN --standalone --httpport 88 # Standalone 模式使用指定端口
+
+# --- DNS-01 验证 (推荐用于通配符证书或无法使用 HTTP 验证的场景) ---
+acme.sh --issue -d DOMAIN --dns DNS_API_HOOK  # 使用 DNS API 自动验证 (推荐)
+#   (需要先设置 API 凭证, 例如 Cloudflare: export CF_Key="..."; export CF_Email="...")
+acme.sh --issue -d DOMAIN -d '*.DOMAIN' --dns DNS_API_HOOK # 颁发通配符证书 (*.example.com)
+acme.sh --issue -d DOMAIN --dns --yes-I-know-dns-manual-mode-enough-to-kill-myself # 手动 DNS 模式 (不推荐, 无法自动续订)
+#   (脚本会提示需要添加的 TXT 记录, 添加后再执行 --renew)
+
+# 提示:
+#   - 查看支持的 DNS API: https://github.com/acmesh-official/acme.sh/wiki/dnsapi
+#   - 证书文件默认保存在 ~/.acme.sh/DOMAIN/
+
+##############################################################################
+# 证书续订 (Renewing Certificates)
+##############################################################################
+
+acme.sh --renew -d DOMAIN                     # 手动续订指定域名的证书
+acme.sh --renew -d DOMAIN --force             # 强制续订 (即使未到期)
+acme.sh --renew-all                           # 续订所有已颁发的证书 (由 cron 自动调用)
+acme.sh --renew-all --force                   # 强制续订所有证书
+
+# 提示:
+#   - 自动续订由 cron 任务处理, 通常无需手动操作。
+#   - 证书默认在到期前 30 天尝试续订。
+
+##############################################################################
+# 证书管理 (Managing Certificates)
+##############################################################################
+
+acme.sh --list                                # 列出所有已颁发的证书及其信息
+acme.sh --info -d DOMAIN                      # 显示指定域名的证书详细信息
+acme.sh --revoke -d DOMAIN                    # 吊销指定域名的证书
+acme.sh --remove -d DOMAIN                    # 从 acme.sh 记录中移除证书 (不删除文件, 不吊销)
+
+##############################################################################
+# 安装证书到服务 (Installing Certificates to Services)
+##############################################################################
+
+# --- 通用安装 ---
+acme.sh --install-cert -d DOMAIN \
+        --key-file       KEY_PATH \
+        --fullchain-file FULLCHAIN_PATH \
+        --cert-file      CERT_PATH \
+        --ca-file        CA_PATH \
+        --reloadcmd      "RELOAD_CMD"
+
+# --- Nginx 示例 ---
+acme.sh --install-cert -d DOMAIN \
+        --key-file       /etc/nginx/ssl/DOMAIN.key \
+        --fullchain-file /etc/nginx/ssl/DOMAIN.cer \
+        --reloadcmd      "service nginx force-reload"
+
+# --- Apache 示例 ---
+acme.sh --install-cert -d DOMAIN \
+        --cert-file      /etc/apache2/ssl/DOMAIN.crt \
+        --key-file       /etc/apache2/ssl/DOMAIN.key \
+        --fullchain-file /etc/apache2/ssl/DOMAIN.fullchain.crt \
+        --reloadcmd      "service apache2 force-reload"
+
+# 提示:
+#   - **重要:** 不要直接使用 ~/.acme.sh/ 目录下的证书文件, 该目录结构可能变化。务必使用 --install-cert 将证书复制到稳定位置。
+#   - --install-cert 会在每次成功续订后自动执行 --reloadcmd。
+
+##############################################################################
+# 调试与日志 (Debugging & Logging)
+##############################################################################
+
+acme.sh --issue ... --log                     # 显示详细日志到 stdout
+acme.sh --issue ... --log /path/to/acme.log   # 将日志保存到文件
+acme.sh --cron --home /path/to/.acme.sh       # 查看 cron 执行的日志 (默认在 ~/.acme.sh/acme.sh.log)
+
+# 默认日志文件: ~/.acme.sh/acme.sh.log
+
+##############################################################################
+# 实用技巧 (Tips and Tricks)
+##############################################################################
+
+# - 始终先用 `--test` 在 Staging 环境测试，避免触发 Let's Encrypt 的速率限制。
+# - 使用 DNS API 验证是获取通配符证书的唯一方式，且通常更稳定。
+# - 保护好你的 DNS API 凭证。
+# - 确保 `--reloadcmd` 能正确无误地重载你的 Web 服务器配置。
+# - 定期检查 `crontab -l` 确保自动续订任务存在。
+# - 检查 `~/.acme.sh/acme.sh.log` 排查续订失败问题。
+
+##############################################################################
+# 示例 (Examples)
+##############################################################################
+
+# 1. 为 example.com 颁发证书 (使用 Nginx 的 webroot) 并安装
+#    acme.sh --issue -d example.com -w /var/www/html
+#    acme.sh --install-cert -d example.com \
+#            --key-file       /etc/nginx/ssl/example.com.key \
+#            --fullchain-file /etc/nginx/ssl/example.com.cer \
+#            --reloadcmd      "service nginx force-reload"
+
+# 2. 为 example.com 及其通配符域名颁发证书 (使用 Cloudflare DNS API)
+#    export CF_Key="YOUR_CLOUDFLARE_API_KEY"
+#    export CF_Email="YOUR_CLOUDFLARE_EMAIL"
+#    acme.sh --issue --dns dns_cf -d example.com -d '*.example.com' --server letsencrypt
+#    # (后续安装步骤同上)
+
+# 3. 使用 Staging 环境测试颁发
+#    acme.sh --issue -d test.example.com -w /var/www/test --test
+
+##############################################################################
+# 更多资源 (Further Resources)
+##############################################################################
+
+# 官方 Wiki: https://github.com/acmesh-official/acme.sh/wiki
+# DNS API 列表: https://github.com/acmesh-official/acme.sh/wiki/dnsapi
+
+# vim: set ts=4 sw=4 tw=0 et ft=sh :

--- a/cheatsheets/security/certbot-cheatsheet.txt
+++ b/cheatsheets/security/certbot-cheatsheet.txt
@@ -1,0 +1,139 @@
+##############################################################################
+# Certbot 速查表 (Certbot Cheatsheet)
+# Let's Encrypt 证书管理工具
+# https://github.com/funnyzak/cli-cheatsheets
+##############################################################################
+
+# 图例 (Legend):
+#   - DOMAIN:   域名 (Domain Name, 例如: example.com, www.example.com)
+#   - EMAIL:    邮箱地址 (Email Address, 用于紧急通知和账户恢复)
+#   - PLUGIN:   Certbot 插件 (Plugin, 例如: webroot, nginx, apache, standalone)
+#   - PATH:     文件路径 (File Path, 例如: /var/www/html, /etc/nginx/conf.d)
+#   - CERTNAME: 证书名称 (Certificate Name, 默认为域名)
+
+##############################################################################
+# 获取证书 (Obtain Certificates)
+##############################################################################
+
+# 自动模式 (Automatic Configuration - 推荐)
+#  - Certbot 尝试自动配置 Web 服务器 (Nginx/Apache)
+
+certbot                                       # 交互式自动配置 (根据提示操作)
+certbot --nginx                               # 自动配置 Nginx (推荐)
+certbot --apache                              # 自动配置 Apache
+
+# 手动模式 (Manual Configuration - 灵活)
+#  - 需要手动配置 Web 服务器，Certbot 仅负责验证和获取证书
+
+certbot certonly                                # 仅获取证书，不自动配置
+certbot certonly --webroot -w PATH -d DOMAIN     # Webroot 插件 (常用)
+certbot certonly --standalone -d DOMAIN        # Standalone 插件 (独立服务器)
+certbot certonly --manual -d DOMAIN             # Manual 插件 (手动 DNS 记录)
+
+# 常用选项 (Common Options for Obtain)
+#   --email EMAIL                             # 注册/恢复邮箱 (重要!)
+#   --agree-tos                               # 同意 Let's Encrypt 服务条款
+#   --no-eff-email                            # 不共享邮箱给 EFF (电子前哨基金会)
+#   --dry-run                                 # 测试模式，不颁发真实证书
+
+# 示例 (Examples for Obtain)
+#   certbot --nginx -d example.com -d www.example.com    # Nginx, 多域名
+#   certbot certonly --webroot -w /var/www/example -d example.com  # Webroot
+
+##############################################################################
+# 续订证书 (Renew Certificates)
+##############################################################################
+
+certbot renew                                 # 续订所有快要过期的证书 (推荐)
+certbot renew --dry-run                         # 续订测试，不实际续订
+certbot renew --force                           # 强制续订所有证书 (慎用)
+certbot renew --cert-name CERTNAME              # 续订指定证书
+
+# 自动续订 (Automatic Renewal - 通过 Cron/Systemd Timer)
+#  - 建议配置系统定时任务 (Cron job 或 Systemd Timer) 每天运行 `certbot renew`
+
+# 提示 (Tips for Renewal)
+#   - Let's Encrypt 证书有效期为 90 天，建议 60 天左右续订
+#   - `certbot renew` 会自动检查并续订快要过期的证书 (默认 30 天内)
+#   - 续订成功后，Web 服务器通常需要重启或重新加载配置才能生效
+
+##############################################################################
+# 撤销证书 (Revoke Certificates)
+##############################################################################
+
+certbot revoke --cert-path PATH                # 撤销指定证书 (根据证书路径)
+certbot revoke --cert-name CERTNAME              # 撤销指定证书 (根据证书名称)
+certbot revoke                                  # 交互式选择证书撤销
+
+# 常用选项 (Common Options for Revoke)
+#   --reason REASON                             # 撤销原因 (可选，例如: keycompromise)
+
+# 注意 (Caution for Revoke)
+#   - 证书撤销操作不可逆，请谨慎操作
+#   - 撤销后需要重新申请证书才能恢复 HTTPS 服务
+
+##############################################################################
+# 管理证书 (Manage Certificates)
+##############################################################################
+
+certbot certificates                            # 列出所有已安装证书
+certbot delete --cert-name CERTNAME              # 删除指定证书 (及其配置)
+certbot update-symlinks                         # 更新证书软链接 (如果手动修改过配置)
+
+# 证书文件路径 (Certificate File Paths)
+#   /etc/letsencrypt/live/CERTNAME/fullchain.pem  # 完整证书链 (服务器证书 + 中间证书)
+#   /etc/letsencrypt/live/CERTNAME/privkey.pem    # 私钥
+#   /etc/letsencrypt/live/CERTNAME/cert.pem       # 服务器证书 (不含中间证书)
+#   /etc/letsencrypt/archive/CERTNAME/            # 证书历史版本归档
+
+##############################################################################
+# 常用选项 (General Options)
+##############################################################################
+
+certbot --version                               # 显示 Certbot 版本
+certbot --help                                  # 显示帮助信息
+certbot --verbose                               # 详细输出
+certbot --quiet                                 # 静默输出
+
+##############################################################################
+# 实用技巧 (Tips and Tricks)
+##############################################################################
+
+# 测试配置 (Dry Run):
+#   certbot --dry-run --nginx -d example.com        # 测试 Nginx 自动配置
+#   certbot renew --dry-run                         # 测试证书续订
+
+# 指定配置文件目录 (非标准环境):
+#   certbot --config-dir /path/to/config --work-dir /path/to/work --logs-dir /path/to/logs ...
+
+#  强制使用 IPv4 或 IPv6 (特定网络环境):
+#   certbot --preferred-challenges http-01 --ipv4 ...  # 强制 IPv4 HTTP 验证
+#   certbot --preferred-challenges http-01 --ipv6 ...  # 强制 IPv6 HTTP 验证
+
+#  使用 DNS 挑战 (适用于无法使用 HTTP 验证的场景):
+#   certbot certonly --manual --preferred-challenges dns -d example.com  # 手动 DNS 验证
+
+##############################################################################
+# 示例 (Examples)
+##############################################################################
+
+# 1. 使用 Nginx 插件获取 example.com 和 www.example.com 的证书:
+#    certbot --nginx -d example.com -d www.example.com
+
+# 2. 使用 Webroot 插件获取 example.net 的证书，网站根目录为 /var/www/example.net:
+#    certbot certonly --webroot -w /var/www/example.net -d example.net
+
+# 3. 续订所有证书 (建议每天定时运行):
+#    certbot renew
+
+# 4. 查看已安装证书列表:
+#    certbot certificates
+
+##############################################################################
+# 鸣谢 & 更多资源 (Credit & Further Resources)
+##############################################################################
+
+# Certbot 官方文档: https://eff-certbot.readthedocs.io/en/stable/
+# Let's Encrypt 官网: https://letsencrypt.org/
+
+# vim: set ts=4 sw=4 tw=0 et ft=txt :


### PR DESCRIPTION
Enhance the README with simplified alias examples and support for Gitee mirror addresses. Introduce new cheatsheets for acme.sh and certbot, providing quick reference commands for Let's Encrypt certificate management.